### PR TITLE
SAPS network config file

### DIFF
--- a/examples/dispatcher.conf.example
+++ b/examples/dispatcher.conf.example
@@ -37,5 +37,5 @@ swift_object_store_path=/path/to/archiver
 swift_object_store_container=container
 swift_object_store_key=mykey
 
-#### SAPS Community Configuration ####
+#### SAPS Network Configuration ####
 saps_neighbors_urls=url1;url2;url3;

--- a/examples/dispatcher.conf.example
+++ b/examples/dispatcher.conf.example
@@ -36,3 +36,6 @@ swift_object_store_host=localhost:8080
 swift_object_store_path=/path/to/archiver
 swift_object_store_container=container
 swift_object_store_key=mykey
+
+#### SAPS Community Configuration ####
+saps_neighbors_urls=url1;url2;url3;

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
@@ -1,15 +1,14 @@
 package org.fogbowcloud.saps.engine.core.dispatcher;
 
-import java.io.IOException;
+import org.fogbowcloud.saps.engine.core.model.ImageTask;
+import org.fogbowcloud.saps.engine.core.model.SapsUser;
+import org.fogbowcloud.saps.notifier.Ward;
+
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-
-import org.fogbowcloud.saps.engine.core.model.ImageTask;
-import org.fogbowcloud.saps.engine.core.model.SapsUser;
-import org.fogbowcloud.saps.notifier.Ward;
 
 public interface SubmissionDispatcher {
 
@@ -21,7 +20,7 @@ public interface SubmissionDispatcher {
 	void addTaskNotificationIntoDB(String submissionId, String taskId, String userEmail)
 			throws SQLException;
 
-	List<Task> addTasks(SubmissionParameters submissionParameters, List<Date> processedDates) throws IOException, ParseException, SQLException;
+	List<Task> addTasks(SubmissionParameters submissionParameters, List<Date> processedDates);
 
 	void addImageTasks(Collection<ImageTask> imageTasks) throws SQLException;
 

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
@@ -248,7 +248,7 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
             try {
                 addImageTask(imageTask);
             } catch (SQLException e) {
-                LOGGER.error("", e);
+                LOGGER.error("Error while adding ImageTask.", e);
             }
         }
     }

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
@@ -243,9 +243,13 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
     }
 
     @Override
-    public void addImageTasks(Collection<ImageTask> imageTasks) throws SQLException {
+    public void addImageTasks(Collection<ImageTask> imageTasks) {
         for (ImageTask imageTask: imageTasks) {
-            addImageTask(imageTask);
+            try {
+                addImageTask(imageTask);
+            } catch (SQLException e) {
+                LOGGER.error("", e);
+            }
         }
     }
 

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManager.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManager.java
@@ -1,8 +1,5 @@
 package org.fogbowcloud.saps.engine.core.dispatcher;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.text.ParseException;
 import java.util.List;
 
 /**
@@ -16,10 +13,7 @@ public interface SubmissionManager {
      *
      * @param submissionParameters Parameters of user submission.
      * @return List of added tasks.
-     * @throws IOException
-     * @throws ParseException
-     * @throws SQLException
      */
-    List<Task> addTasks(SubmissionParameters submissionParameters) throws IOException, ParseException, SQLException;
+    List<Task> addTasks(SubmissionParameters submissionParameters);
 
 }

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
@@ -23,6 +23,7 @@ public class SubmissionManagerImpl implements SubmissionManager {
     private static final Logger LOGGER = Logger.getLogger(SubmissionManagerImpl.class);
 
     private static final String SAPS_NEIGHBORS_URLS = "saps_neighbors_urls";
+    private static final String PROCESSED_TASKS_URN = "/archivedTask";
 
     private Properties properties;
     private SubmissionDispatcher submissionDispatcher;
@@ -78,8 +79,7 @@ public class SubmissionManagerImpl implements SubmissionManager {
                                                                   SubmissionParameters submissionParameters) {
         List<ImageTask> processedTasks = new ArrayList<>();
         try {
-            String processedTasksURN = "/archivedTasks";
-            ClientResource clientResource = new ClientResource(SAPSNeighborUrl + processedTasksURN);
+            ClientResource clientResource = new ClientResource(SAPSNeighborUrl + PROCESSED_TASKS_URN);
             Representation response = clientResource.post(submissionParameters, MediaType.APPLICATION_JSON);
             processedTasks = extractTasksList(response);
         } catch (Throwable t) {

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
@@ -78,7 +78,8 @@ public class SubmissionManagerImpl implements SubmissionManager {
                                                                   SubmissionParameters submissionParameters) {
         List<ImageTask> processedTasks = new ArrayList<>();
         try {
-            ClientResource clientResource = new ClientResource(SAPSNeighborUrl);
+            String processedTasksURN = "/archivedTasks";
+            ClientResource clientResource = new ClientResource(SAPSNeighborUrl + processedTasksURN);
             Representation response = clientResource.post(submissionParameters, MediaType.APPLICATION_JSON);
             processedTasks = extractTasksList(response);
         } catch (Throwable t) {

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
@@ -117,7 +117,7 @@ public class SubmissionManagerImpl implements SubmissionManager {
     private String[] getSAPSNeighborsUrls() {
         String separator = ";";
         String SAPSNeighborsUrls = properties.getProperty(SAPS_NEIGHBORS_URLS);
-        return !Objects.isNull(SAPSNeighborsUrls) ? SAPSNeighborsUrls.split(separator)
+        return Objects.nonNull(SAPSNeighborsUrls) ? SAPSNeighborsUrls.split(separator)
                 : new String[]{};
     }
 

--- a/src/main/java/org/fogbowcloud/saps/engine/scheduler/restlet/DatabaseApplication.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/scheduler/restlet/DatabaseApplication.java
@@ -113,7 +113,7 @@ public class DatabaseApplication extends Application {
 		return submissionDispatcher.getTaskInDB(taskId);
 	}
 
-	public List<Task> addTasks(SubmissionParameters submissionParameters) throws IOException, ParseException, SQLException {
+	public List<Task> addTasks(SubmissionParameters submissionParameters) {
 		return submissionManager.addTasks(submissionParameters);
 	}
 

--- a/src/main/java/org/fogbowcloud/saps/engine/scheduler/restlet/DatabaseApplication.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/scheduler/restlet/DatabaseApplication.java
@@ -42,7 +42,7 @@ public class DatabaseApplication extends Application {
 	public DatabaseApplication(Properties properties) throws Exception {
 		this.properties = properties;
 		this.submissionDispatcher = new SubmissionDispatcherImpl(properties);
-		this.submissionManager = new SubmissionManagerImpl(this.submissionDispatcher);
+		this.submissionManager = new SubmissionManagerImpl(properties, this.submissionDispatcher);
 
 		// CORS configuration
 		CorsService cors = new CorsService();


### PR DESCRIPTION
**Purpose of this PR:**
Add a property on config file that will store all SAPS neighbors URLs and use this property to retrieve the URLs on SubmissionManager

**What problem will be solved:**
Now the SubmissionManager will be able to access the list of SAPS neighbors URLs provided by user through config file

**Extra additions:**
Also, I improved exception handling to avoid three main problems:
1. Reuse of remotely processed tasks interrupt the local submission processing (if the reuse fails, the submission must be fully partitioned in local tasks)
2. Fail of communication with one neighbor interfere other communications
3. Fail of insertion of one remotely processed task interfere insertion of other remotely processed tasks