### PR TITLE
[bugfix] Join processed and created tasks

### DIFF
--- a/examples/dispatcher.conf.example
+++ b/examples/dispatcher.conf.example
@@ -37,5 +37,5 @@ swift_object_store_path=/path/to/archiver
 swift_object_store_container=container
 swift_object_store_key=mykey
 
-#### SAPS Community Configuration ####
+#### SAPS Network Configuration ####
 saps_neighbors_urls=url1;url2;url3;

--- a/examples/dispatcher.conf.example
+++ b/examples/dispatcher.conf.example
@@ -36,3 +36,6 @@ swift_object_store_host=localhost:8080
 swift_object_store_path=/path/to/archiver
 swift_object_store_container=container
 swift_object_store_key=mykey
+
+#### SAPS Community Configuration ####
+saps_neighbors_urls=url1;url2;url3;

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
@@ -1,15 +1,14 @@
 package org.fogbowcloud.saps.engine.core.dispatcher;
 
-import java.io.IOException;
+import org.fogbowcloud.saps.engine.core.model.ImageTask;
+import org.fogbowcloud.saps.engine.core.model.SapsUser;
+import org.fogbowcloud.saps.notifier.Ward;
+
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-
-import org.fogbowcloud.saps.engine.core.model.ImageTask;
-import org.fogbowcloud.saps.engine.core.model.SapsUser;
-import org.fogbowcloud.saps.notifier.Ward;
 
 public interface SubmissionDispatcher {
 
@@ -21,7 +20,7 @@ public interface SubmissionDispatcher {
 	void addTaskNotificationIntoDB(String submissionId, String taskId, String userEmail)
 			throws SQLException;
 
-	List<Task> addTasks(SubmissionParameters submissionParameters, List<Date> processedDates) throws IOException, ParseException, SQLException;
+	List<Task> addTasks(SubmissionParameters submissionParameters, List<Date> processedDates);
 
 	void addImageTasks(Collection<ImageTask> imageTasks) throws SQLException;
 

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
@@ -22,9 +22,9 @@ public interface SubmissionDispatcher {
 
 	List<Task> addTasks(SubmissionParameters submissionParameters, List<Date> processedDates);
 
-	void addImageTasks(Collection<ImageTask> imageTasks) throws SQLException;
+	List<Task> addImageTasks(Collection<ImageTask> imageTasks);
 
-	void addImageTask(ImageTask imageTask) throws SQLException;
+	Task addImageTask(ImageTask imageTask) throws SQLException;
 
 	List<Ward> getUsersToNotify() throws SQLException;
 

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
@@ -248,7 +248,7 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
             try {
                 addImageTask(imageTask);
             } catch (SQLException e) {
-                LOGGER.error("", e);
+                LOGGER.error("Error while adding ImageTask.", e);
             }
         }
     }

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
@@ -243,9 +243,13 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
     }
 
     @Override
-    public void addImageTasks(Collection<ImageTask> imageTasks) throws SQLException {
+    public void addImageTasks(Collection<ImageTask> imageTasks) {
         for (ImageTask imageTask: imageTasks) {
-            addImageTask(imageTask);
+            try {
+                addImageTask(imageTask);
+            } catch (SQLException e) {
+                LOGGER.error("", e);
+            }
         }
     }
 

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
@@ -243,19 +243,26 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
     }
 
     @Override
-    public void addImageTasks(Collection<ImageTask> imageTasks) {
+    public List<Task> addImageTasks(Collection<ImageTask> imageTasks) {
+        List<Task> addedTasks = new ArrayList<>();
         for (ImageTask imageTask: imageTasks) {
             try {
-                addImageTask(imageTask);
+                addedTasks.add(addImageTask(imageTask));
             } catch (SQLException e) {
                 LOGGER.error("Error while adding ImageTask.", e);
             }
         }
+        return addedTasks;
     }
 
     @Override
-    public void addImageTask(ImageTask imageTask) throws SQLException {
+    public Task addImageTask(ImageTask imageTask) throws SQLException {
         imageStore.addImageTask(imageTask);
+        getImageStore().addStateStamp(imageTask.getTaskId(), imageTask.getState(),
+                getImageStore().getTask(imageTask.getTaskId()).getUpdateTime());
+        Task task = new Task(UUID.randomUUID().toString());
+        task.setImageTask(imageTask);
+        return task;
     }
 
     public List<ImageTask> getTaskListInDB() throws SQLException, ParseException {

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManager.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManager.java
@@ -1,8 +1,5 @@
 package org.fogbowcloud.saps.engine.core.dispatcher;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.text.ParseException;
 import java.util.List;
 
 /**
@@ -16,10 +13,7 @@ public interface SubmissionManager {
      *
      * @param submissionParameters Parameters of user submission.
      * @return List of added tasks.
-     * @throws IOException
-     * @throws ParseException
-     * @throws SQLException
      */
-    List<Task> addTasks(SubmissionParameters submissionParameters) throws IOException, ParseException, SQLException;
+    List<Task> addTasks(SubmissionParameters submissionParameters);
 
 }

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
@@ -23,6 +23,7 @@ public class SubmissionManagerImpl implements SubmissionManager {
     private static final Logger LOGGER = Logger.getLogger(SubmissionManagerImpl.class);
 
     private static final String SAPS_NEIGHBORS_URLS = "saps_neighbors_urls";
+    private static final String PROCESSED_TASKS_URN = "/archivedTask";
 
     private Properties properties;
     private SubmissionDispatcher submissionDispatcher;
@@ -78,8 +79,7 @@ public class SubmissionManagerImpl implements SubmissionManager {
                                                                   SubmissionParameters submissionParameters) {
         List<ImageTask> processedTasks = new ArrayList<>();
         try {
-            String processedTasksURN = "/archivedTasks";
-            ClientResource clientResource = new ClientResource(SAPSNeighborUrl + processedTasksURN);
+            ClientResource clientResource = new ClientResource(SAPSNeighborUrl + PROCESSED_TASKS_URN);
             Representation response = clientResource.post(submissionParameters, MediaType.APPLICATION_JSON);
             processedTasks = extractTasksList(response);
         } catch (Throwable t) {

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
@@ -78,7 +78,8 @@ public class SubmissionManagerImpl implements SubmissionManager {
                                                                   SubmissionParameters submissionParameters) {
         List<ImageTask> processedTasks = new ArrayList<>();
         try {
-            ClientResource clientResource = new ClientResource(SAPSNeighborUrl);
+            String processedTasksURN = "/archivedTasks";
+            ClientResource clientResource = new ClientResource(SAPSNeighborUrl + processedTasksURN);
             Representation response = clientResource.post(submissionParameters, MediaType.APPLICATION_JSON);
             processedTasks = extractTasksList(response);
         } catch (Throwable t) {

--- a/src/main/java/org/fogbowcloud/saps/engine/scheduler/restlet/DatabaseApplication.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/scheduler/restlet/DatabaseApplication.java
@@ -113,7 +113,7 @@ public class DatabaseApplication extends Application {
 		return submissionDispatcher.getTaskInDB(taskId);
 	}
 
-	public List<Task> addTasks(SubmissionParameters submissionParameters) throws IOException, ParseException, SQLException {
+	public List<Task> addTasks(SubmissionParameters submissionParameters) {
 		return submissionManager.addTasks(submissionParameters);
 	}
 

--- a/src/main/java/org/fogbowcloud/saps/engine/scheduler/restlet/DatabaseApplication.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/scheduler/restlet/DatabaseApplication.java
@@ -42,7 +42,7 @@ public class DatabaseApplication extends Application {
 	public DatabaseApplication(Properties properties) throws Exception {
 		this.properties = properties;
 		this.submissionDispatcher = new SubmissionDispatcherImpl(properties);
-		this.submissionManager = new SubmissionManagerImpl(this.submissionDispatcher);
+		this.submissionManager = new SubmissionManagerImpl(properties, this.submissionDispatcher);
 
 		// CORS configuration
 		CorsService cors = new CorsService();


### PR DESCRIPTION
**What is the bug?**
1. When processing a submission, only the tasks created locally had a notification attached to it, because the tasks from SAPS neighbors weren't joined to the list of added tasks;
2. When getting tasks from neighbors, duplicates were not being removed.

**What is the fix?**
1. Join the two lists, one of already processed tasks and one of localy added tasks;
2. Remove duplicates - based on date, region and satellite - before insert on local catalog.

**Depends on PR(s):** #4