### PR TITLE
[bugfix] Excluding ImageTasks local creation with other regions and satellites

### DIFF
--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
@@ -9,6 +9,7 @@ import java.text.ParseException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public interface SubmissionDispatcher {
 
@@ -20,7 +21,7 @@ public interface SubmissionDispatcher {
 	void addTaskNotificationIntoDB(String submissionId, String taskId, String userEmail)
 			throws SQLException;
 
-	List<Task> addTasks(SubmissionParameters submissionParameters, List<Date> processedDates);
+	List<Task> addTasks(SubmissionParameters submissionParameters, Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate);
 
 	List<Task> addImageTasks(Collection<ImageTask> imageTasks);
 

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcher.java
@@ -21,7 +21,8 @@ public interface SubmissionDispatcher {
 	void addTaskNotificationIntoDB(String submissionId, String taskId, String userEmail)
 			throws SQLException;
 
-	List<Task> addTasks(SubmissionParameters submissionParameters, Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate);
+	List<Task> addTasks(SubmissionParameters submissionParameters,
+						Map<Date, List<ImageTask>> processedImageTasksGroupedByDate);
 
 	List<Task> addImageTasks(Collection<ImageTask> imageTasks);
 

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
@@ -12,6 +12,8 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -153,7 +155,8 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
     }
 
     @Override
-    public List<Task> addTasks(SubmissionParameters submissionParameters, List<Date> processedDates) {
+    public List<Task> addTasks(SubmissionParameters submissionParameters,
+                               Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate) {
         Set<String> regions = repository.getRegionsFromArea(
                 submissionParameters.getLowerLeftLatitude(),
                 submissionParameters.getLowerLeftLongitude(),
@@ -163,19 +166,14 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
         List<Date> datesToProcess = DateUtil.getDateListFromInterval(
                 submissionParameters.getInitDate(),
                 submissionParameters.getEndDate());
-        // Filter already processed dates
-        datesToProcess = datesToProcess.stream()
-                .filter(processedDates::contains)
+        List<Task> createdTasks = datesToProcess.stream()
+                .map(currentDate -> addTasksForDate(
+                        currentDate,
+                        submissionParameters,
+                        regions,
+                        imageTasksProcessedGroupedByDate))
+                .flatMap(Collection::stream)
                 .collect(Collectors.toList());
-        List<Task> createdTasks = new ArrayList<>();
-        for (Date currentDate : datesToProcess) {
-            List<Task> createdTasksForCurrentDate = addTasksForDate(
-                    currentDate,
-                    submissionParameters,
-                    regions
-            );
-            createdTasks.addAll(createdTasksForCurrentDate);
-        }
         return createdTasks;
     }
 
@@ -183,14 +181,16 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
      * Adds all the needed tasks for specified date. It will add a task for every
      * satellite in operation in specified date, for every specified region.
      *
-     * @param date                 Date of processing.
-     * @param submissionParameters Submission parameters specified by user.
-     * @param regions              Regions to be processed.
+     * @param date                             Date of processing.
+     * @param submissionParameters             Submission parameters specified by user.
+     * @param regions                          Regions to be processed.
+     * @param imageTasksProcessedGroupedByDate Lists of processed ImageTasks grouped
+     *                                         by date.
      * @return List of added tasks.
      */
     private List<Task> addTasksForDate(Date date,
                                        SubmissionParameters submissionParameters,
-                                       Set<String> regions) {
+                                       Set<String> regions, Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate) {
         LOGGER.debug("Adding tasks for date: " + date);
         int startingYear = DateUtil.calendarFromDate(date).get(Calendar.YEAR);
         List<String> satellitesInOperation = DatasetUtil.getSatsInOperationByYear(startingYear);
@@ -198,10 +198,15 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
         for (String satellite : satellitesInOperation) {
             for (String region : regions) {
                 try {
-                    ImageTask imageTask = addImageTask(date, submissionParameters, region, satellite);
-                    Task task = new Task(UUID.randomUUID().toString());
-                    task.setImageTask(imageTask);
-                    createdTasksForDate.add(task);
+                    if (!haveAlreadyBeenProcessed(date, satellite, region, imageTasksProcessedGroupedByDate)) {
+                        ImageTask imageTask = addImageTask(date, submissionParameters, region, satellite);
+                        Task task = new Task(UUID.randomUUID().toString());
+                        task.setImageTask(imageTask);
+                        createdTasksForDate.add(task);
+                    } else {
+                        LOGGER.debug(String.format("ImageTask with date: %s; satellite: %s and; region: %s; has " +
+                                "already been remotely processed, skipping local creation", date, satellite, region));
+                    }
                 } catch (SQLException e) {
                     LOGGER.error("Error while adding image to database", e);
                 }
@@ -211,9 +216,31 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
     }
 
     /**
+     * Returns if specified date, satellite and region have already been processed.
+     *
+     * @param date                             Date to be processed.
+     * @param satellite                        Satellite to be processed.
+     * @param region                           Region to be processed.
+     * @param imageTasksProcessedGroupedByDate Lists of processed ImageTasks grouped
+     *                                         by date.
+     * @return {@code true} if there's a ImageTask in {@param imageTasksProcessedGroupedByDate}
+     * that were processed in the specified date with specified satellite and region.
+     */
+    private boolean haveAlreadyBeenProcessed(Date date, String satellite, String region,
+                                             Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate) {
+        List<ImageTask> imageTasksProcessedInDate = imageTasksProcessedGroupedByDate.get(date);
+        if (Objects.isNull(imageTasksProcessedInDate) || imageTasksProcessedInDate.isEmpty()) {
+            return false;
+        }
+        return imageTasksProcessedInDate.stream()
+                .anyMatch(imageTask -> imageTask.getDataset().equals(satellite)
+                        && imageTask.getRegion().equals(region));
+    }
+
+    /**
      * Adds a ImageTask to ImageStore for specified date, region and satellite.
      *
-     * @param date                 Date of processing.
+     * @param date                 Date to be processed.
      * @param submissionParameters Submission parameters specified by user.
      * @param region               Region to be processed.
      * @param satellite            Satellite that provide the landsat image.

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionDispatcherImpl.java
@@ -156,7 +156,7 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
 
     @Override
     public List<Task> addTasks(SubmissionParameters submissionParameters,
-                               Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate) {
+                               Map<Date, List<ImageTask>> processedImageTasksGroupedByDate) {
         Set<String> regions = repository.getRegionsFromArea(
                 submissionParameters.getLowerLeftLatitude(),
                 submissionParameters.getLowerLeftLongitude(),
@@ -171,7 +171,7 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
                         currentDate,
                         submissionParameters,
                         regions,
-                        imageTasksProcessedGroupedByDate))
+                        processedImageTasksGroupedByDate))
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
         return createdTasks;
@@ -184,13 +184,13 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
      * @param date                             Date of processing.
      * @param submissionParameters             Submission parameters specified by user.
      * @param regions                          Regions to be processed.
-     * @param imageTasksProcessedGroupedByDate Lists of processed ImageTasks grouped
+     * @param processedImageTasksGroupedByDate Lists of processed ImageTasks grouped
      *                                         by date.
      * @return List of added tasks.
      */
     private List<Task> addTasksForDate(Date date,
                                        SubmissionParameters submissionParameters,
-                                       Set<String> regions, Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate) {
+                                       Set<String> regions, Map<Date, List<ImageTask>> processedImageTasksGroupedByDate) {
         LOGGER.debug("Adding tasks for date: " + date);
         int startingYear = DateUtil.calendarFromDate(date).get(Calendar.YEAR);
         List<String> satellitesInOperation = DatasetUtil.getSatsInOperationByYear(startingYear);
@@ -198,7 +198,7 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
         for (String satellite : satellitesInOperation) {
             for (String region : regions) {
                 try {
-                    if (!haveAlreadyBeenProcessed(date, satellite, region, imageTasksProcessedGroupedByDate)) {
+                    if (!haveAlreadyBeenProcessed(date, satellite, region, processedImageTasksGroupedByDate)) {
                         ImageTask imageTask = addImageTask(date, submissionParameters, region, satellite);
                         Task task = new Task(UUID.randomUUID().toString());
                         task.setImageTask(imageTask);
@@ -221,18 +221,19 @@ public class SubmissionDispatcherImpl implements SubmissionDispatcher {
      * @param date                             Date to be processed.
      * @param satellite                        Satellite to be processed.
      * @param region                           Region to be processed.
-     * @param imageTasksProcessedGroupedByDate Lists of processed ImageTasks grouped
+     * @param processedImageTasksGroupedByDate Lists of processed ImageTasks grouped
      *                                         by date.
-     * @return {@code true} if there's a ImageTask in {@param imageTasksProcessedGroupedByDate}
-     * that were processed in the specified date with specified satellite and region.
+     * @return {@code true} if there's a ImageTask in {@param processedImageTasksGroupedByDate}
+     * that were processed in the specified date with specified satellite and region. {@code
+     * false} otherwise.
      */
     private boolean haveAlreadyBeenProcessed(Date date, String satellite, String region,
-                                             Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate) {
-        List<ImageTask> imageTasksProcessedInDate = imageTasksProcessedGroupedByDate.get(date);
-        if (Objects.isNull(imageTasksProcessedInDate) || imageTasksProcessedInDate.isEmpty()) {
+                                             Map<Date, List<ImageTask>> processedImageTasksGroupedByDate) {
+        List<ImageTask> processedImageTasksInDate = processedImageTasksGroupedByDate.get(date);
+        if (Objects.isNull(processedImageTasksInDate) || processedImageTasksInDate.isEmpty()) {
             return false;
         }
-        return imageTasksProcessedInDate.stream()
+        return processedImageTasksInDate.stream()
                 .anyMatch(imageTask -> imageTask.getDataset().equals(satellite)
                         && imageTask.getRegion().equals(region));
     }

--- a/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
+++ b/src/main/java/org/fogbowcloud/saps/engine/core/dispatcher/SubmissionManagerImpl.java
@@ -36,7 +36,7 @@ public class SubmissionManagerImpl implements SubmissionManager {
     @Override
     public List<Task> addTasks(SubmissionParameters submissionParameters) {
         List<Task> processedTasks = new ArrayList<>();
-        List<Date> processedDates = new ArrayList<>();
+        Map<Date, List<ImageTask>> imageTasksProcessedGroupedByDate = new HashMap<>();
         try {
             List<ImageTask> processedImageTasks = getAllRemotelyProcessedTasks(submissionParameters);
             if (!processedImageTasks.isEmpty()) {
@@ -44,14 +44,14 @@ public class SubmissionManagerImpl implements SubmissionManager {
                     processedTask.setState(ImageTaskState.REMOTELY_ARCHIVED);
                 }
                 processedTasks = submissionDispatcher.addImageTasks(processedImageTasks);
-                processedDates = processedImageTasks.stream()
-                        .map(ImageTask::getImageDate)
-                        .collect(Collectors.toList());
+                imageTasksProcessedGroupedByDate = processedTasks.stream()
+                        .map(Task::getImageTask)
+                        .collect(Collectors.groupingBy(ImageTask::getImageDate));
             }
         } catch (Throwable t) {
             LOGGER.error("Error while adding remotely processed tasks.", t);
         }
-        List<Task> addedTasks = submissionDispatcher.addTasks(submissionParameters, processedDates);
+        List<Task> addedTasks = submissionDispatcher.addTasks(submissionParameters, imageTasksProcessedGroupedByDate);
         List<Task> allAddedTasks = new ArrayList<>();
         allAddedTasks.addAll(processedTasks);
         allAddedTasks.addAll(addedTasks);


### PR DESCRIPTION
**What is the bug?**
When skipping ImageTasks local creation based on remotely processed ones, the SubmissionDispatcher is skipping a date regardless if there are or not remote ImageTasks, not only with same date, but with same region and satellite too (considering these 3 parameters as what makes the identification of an ImageTask).

**What is the fix?**
Instead of use a list of dates that have already been processed remotely, use a map that have a date as key and a list of remote ImageTasks processed in that date as value. Then, the SubmissionDispatcher tries to process every single date of submission date interval and only skips a local creation if there is a remote ImageTask with same date, region and satellite, not only with same date as was before.